### PR TITLE
Add dark theme palette and responsive layout

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.25.0",
+        "@tailwindcss/typography": "^0.5.16",
         "@types/react": "^19.1.2",
         "@types/react-dom": "^19.1.2",
         "@vitejs/plugin-react": "^4.4.1",
@@ -1526,6 +1527,22 @@
         "node": ">= 10"
       }
     },
+    "node_modules/@tailwindcss/typography": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/typography/-/typography-0.5.16.tgz",
+      "integrity": "sha512-0wDLwCVF5V3x3b1SGXPCDcdsbDHMBe+lkFzBRaHeLvNi+nrrnZ1lA18u+OTWO8iSWU2GxUOCvlXtDuqftc1oiA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lodash.castarray": "^4.4.0",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.merge": "^4.6.2",
+        "postcss-selector-parser": "6.0.10"
+      },
+      "peerDependencies": {
+        "tailwindcss": ">=3.0.0 || insiders || >=4.0.0-alpha.20 || >=4.0.0-beta.1"
+      }
+    },
     "node_modules/@tailwindcss/vite": {
       "version": "4.1.8",
       "resolved": "https://registry.npmjs.org/@tailwindcss/vite/-/vite-4.1.8.tgz",
@@ -1917,6 +1934,19 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/cssesc": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
+      "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "cssesc": "bin/cssesc"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/csstype": {
@@ -2798,6 +2828,20 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/lodash.castarray": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.castarray/-/lodash.castarray-4.4.0.tgz",
+      "integrity": "sha512-aVx8ztPv7/2ULbArGJ2Y42bG1mEQ5mGjpdvrbJcJFU3TbYybe+QlLS4pst9zV52ymy2in1KpFPiZnAOATxD4+Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
@@ -3049,6 +3093,20 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/postcss-selector-parser": {
+      "version": "6.0.10",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.10.tgz",
+      "integrity": "sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/postcss-value-parser": {
@@ -3402,6 +3460,13 @@
       "dependencies": {
         "punycode": "^2.1.0"
       }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/vite": {
       "version": "6.3.5",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.25.0",
+    "@tailwindcss/typography": "^0.5.16",
     "@types/react": "^19.1.2",
     "@types/react-dom": "^19.1.2",
     "@vitejs/plugin-react": "^4.4.1",

--- a/src/App.css
+++ b/src/App.css
@@ -1,3 +1,5 @@
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap');
+
 #root {
   max-width: 1280px;
   margin: 0 auto;
@@ -40,8 +42,6 @@
 .read-the-docs {
   color: #888;
 }
-/* Import Inter font from Google Fonts */
-@import url('https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap');
 body {
     font-family: 'Inter', sans-serif;
     -webkit-font-smoothing: antialiased;

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -12,6 +12,8 @@ import Unit3Quiz from './pages/Unit3QuizComponent.jsx';
 import Unit3Flashcards from './pages/Unit3FlashcardsComponent.jsx';
 import Unit3PracticeQuestions from './pages/Unit3PracticeQuestionsComponent.jsx';
 import KeySkillsHub from './pages/key-skills-hub.jsx';
+import Progress from './pages/ProgressComponent.jsx';
+import SearchBar from './components/SearchBar.jsx';
 import NotFound from './pages/NotFoundComponent.jsx';
 
 import './App.css';
@@ -29,7 +31,7 @@ function ScrollToTopButton() {
   const scrollTop = () => window.scrollTo({ top: 0, behavior: 'smooth' });
 
   return visible ? (
-    <button onClick={scrollTop} className="fixed bottom-5 right-5 bg-purple-600 hover:bg-purple-700 text-white font-bold p-3 rounded-full shadow-lg z-40">
+    <button onClick={scrollTop} className="fixed bottom-5 right-5 bg-purple-600 hover:bg-purple-700 text-white font-bold p-3 rounded-full shadow-lg z-40 transition-colors">
       <svg xmlns="http://www.w3.org/2000/svg" className="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth="2">
         <path strokeLinecap="round" strokeLinejoin="round" d="M5 15l7-7 7 7" />
       </svg>
@@ -41,57 +43,105 @@ function ScrollToTopOnRouteChange() {
   const { pathname } = useLocation();
   useEffect(() => {
     window.scrollTo(0, 0);
+    try {
+      localStorage.setItem('visited_' + pathname, 'true');
+    } catch {}
   }, [pathname]);
   return null;
 }
 
 function App() {
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
+  const [darkMode, setDarkMode] = useState(() =>
+    localStorage.getItem('theme') === 'dark'
+  );
+
+  useEffect(() => {
+    if (darkMode) {
+      document.documentElement.classList.add('dark');
+      localStorage.setItem('theme', 'dark');
+    } else {
+      document.documentElement.classList.remove('dark');
+      localStorage.setItem('theme', 'light');
+    }
+  }, [darkMode]);
 
   return (
     <Router>
       <ScrollToTopOnRouteChange />
-      <div className="bg-slate-900 text-slate-200 font-sans antialiased">
-        <header className="bg-slate-800 shadow-lg sticky top-0 z-50">
-          <nav className="container mx-auto px-6 py-4 flex justify-between items-center">
-            <Link to="/" className="text-2xl font-bold text-purple-400 hover:text-purple-300">HHD Hub</Link>
-            <button onClick={() => setMobileMenuOpen(!mobileMenuOpen)} className="md:hidden text-slate-200 hover:text-purple-300">
-              <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                {mobileMenuOpen ? (
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M6 18L18 6M6 6l12 12" />
+      <div className="font-sans antialiased min-h-screen bg-gray-50 dark:bg-outer text-slate-800 dark:text-slate-200 transition-colors">
+        <header className="bg-gray-100 dark:bg-surface shadow-lg sticky top-0 z-50 transition-colors">
+          <nav className="max-w-5xl mx-auto px-4 md:px-8 py-4 flex items-center justify-between">
+            <Link to="/" className="text-2xl font-bold text-purple-500 dark:text-purple-400 hover:text-purple-600 dark:hover:text-purple-300 transition-colors">HHD Hub</Link>
+            <div className="flex items-center space-x-3">
+              <div className="hidden md:block">
+                <SearchBar />
+              </div>
+              <button
+                onClick={() => setDarkMode(!darkMode)}
+                className="hidden md:inline-block text-slate-600 dark:text-slate-300 hover:text-purple-600 dark:hover:text-purple-300 transition-colors"
+                aria-label="Toggle dark mode"
+              >
+                {darkMode ? (
+                  <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M12 3v1m0 16v1m8.66-9h-1M4.34 12h-1m15.36 5.36l-.7-.7m-12.72 0l-.7.7m12.72-10.72l-.7.7m-12.72 0l-.7-.7M17 12a5 5 0 11-10 0 5 5 0 0110 0z" />
+                  </svg>
                 ) : (
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M4 6h16M4 12h16m-7 6h7" />
+                  <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M21 12.79A9 9 0 1111.21 3 7 7 0 0021 12.79z" />
+                  </svg>
                 )}
-              </svg>
-            </button>
-            <ul className="hidden md:flex space-x-4">
-              <li><Link to="/" className="nav-link hover:text-purple-300 px-3 py-2 rounded-md">Home</Link></li>
-              <li><Link to="/unit3" className="nav-link hover:text-purple-300 px-3 py-2 rounded-md">Unit 3</Link></li>
-              <li><Link to="/unit4" className="nav-link hover:text-purple-300 px-3 py-2 rounded-md">Unit 4</Link></li>
-              <li><Link to="/assessment-prep" className="nav-link hover:text-purple-300 px-3 py-2 rounded-md">Assessment Prep</Link></li>
-              <li><Link to="/glossary" className="nav-link hover:text-purple-300 px-3 py-2 rounded-md">Glossary</Link></li>
+              </button>
+              <button onClick={() => setMobileMenuOpen(!mobileMenuOpen)} className="md:hidden text-slate-600 dark:text-slate-200 hover:text-purple-600 dark:hover:text-purple-300 transition-colors">
+                <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  {mobileMenuOpen ? (
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M6 18L18 6M6 6l12 12" />
+                  ) : (
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M4 6h16M4 12h16m-7 6h7" />
+                  )}
+                </svg>
+              </button>
+            </div>
+            <ul className="hidden md:flex space-x-6">
+              <li><Link to="/" className="nav-link px-3 py-2 rounded-md text-slate-700 dark:text-slate-300 hover:text-purple-600 dark:hover:text-purple-400 transition-colors">Home</Link></li>
+              <li><Link to="/unit3" className="nav-link px-3 py-2 rounded-md text-slate-700 dark:text-slate-300 hover:text-purple-600 dark:hover:text-purple-400 transition-colors">Unit 3</Link></li>
+              <li><Link to="/unit4" className="nav-link px-3 py-2 rounded-md text-slate-700 dark:text-slate-300 hover:text-purple-600 dark:hover:text-purple-400 transition-colors">Unit 4</Link></li>
+              <li><Link to="/assessment-prep" className="nav-link px-3 py-2 rounded-md text-slate-700 dark:text-slate-300 hover:text-purple-600 dark:hover:text-purple-400 transition-colors">Assessment Prep</Link></li>
+              <li><Link to="/glossary" className="nav-link px-3 py-2 rounded-md text-slate-700 dark:text-slate-300 hover:text-purple-600 dark:hover:text-purple-400 transition-colors">Glossary</Link></li>
+              <li><Link to="/progress" className="nav-link px-3 py-2 rounded-md text-slate-700 dark:text-slate-300 hover:text-purple-600 dark:hover:text-purple-400 transition-colors">Progress</Link></li>
             </ul>
           </nav>
           {mobileMenuOpen && (
-            <div className="md:hidden bg-slate-800">
+            <div className="md:hidden bg-gray-100 dark:bg-surface">
               <ul className="flex flex-col items-center py-2 space-y-2">
-                <li><Link to="/" onClick={() => setMobileMenuOpen(false)}>Home</Link></li>
-                <li><Link to="/unit3" onClick={() => setMobileMenuOpen(false)}>Unit 3</Link></li>
-                <li><Link to="/unit4" onClick={() => setMobileMenuOpen(false)}>Unit 4</Link></li>
-                <li><Link to="/assessment-prep" onClick={() => setMobileMenuOpen(false)}>Assessment Prep</Link></li>
-                <li><Link to="/glossary" onClick={() => setMobileMenuOpen(false)}>Glossary</Link></li>
+                <li className="w-11/12"><SearchBar /></li>
+                <li>
+                  <button
+                    onClick={() => setDarkMode(!darkMode)}
+                    className="text-slate-200 hover:text-purple-400 transition-colors"
+                  >
+                    {darkMode ? 'Light Mode' : 'Dark Mode'}
+                  </button>
+                </li>
+                <li><Link to="/" onClick={() => setMobileMenuOpen(false)} className="transition-colors hover:text-purple-600">Home</Link></li>
+                <li><Link to="/unit3" onClick={() => setMobileMenuOpen(false)} className="transition-colors hover:text-purple-600">Unit 3</Link></li>
+                <li><Link to="/unit4" onClick={() => setMobileMenuOpen(false)} className="transition-colors hover:text-purple-600">Unit 4</Link></li>
+                <li><Link to="/assessment-prep" onClick={() => setMobileMenuOpen(false)} className="transition-colors hover:text-purple-600">Assessment Prep</Link></li>
+                <li><Link to="/glossary" onClick={() => setMobileMenuOpen(false)} className="transition-colors hover:text-purple-600">Glossary</Link></li>
+                <li><Link to="/progress" onClick={() => setMobileMenuOpen(false)} className="transition-colors hover:text-purple-600">Progress</Link></li>
               </ul>
             </div>
           )}
         </header>
 
-        <main className="container mx-auto px-6 py-8 min-h-[calc(100vh-160px)]">
+        <main className="max-w-5xl mx-auto px-4 md:px-8 py-8 min-h-[calc(100vh-160px)]">
           <Routes>
             <Route path="/" element={<Home />} />
             <Route path="/unit3" element={<Unit3 />} />
             <Route path="/unit4" element={<Unit4 />} />
             <Route path="/assessment-prep" element={<AssessmentPrep />} />
             <Route path="/glossary" element={<Glossary />} />
+            <Route path="/progress" element={<Progress />} />
             <Route path="/keyskillshub" element={<KeySkillsHub />} />
             <Route path="/unit3-sac2-prep" element={<Unit3SAC2Prep />} />
             <Route path="/unit3-quiz" element={<Unit3Quiz />} />
@@ -101,7 +151,7 @@ function App() {
           </Routes>
         </main>
 
-        <footer className="bg-slate-800 text-slate-400 text-center p-6 shadow-top">
+        <footer className="bg-gray-100 dark:bg-surface text-slate-500 dark:text-slate-400 text-center p-6 shadow-top transition-colors">
           <p>&copy; {new Date().getFullYear()} VCE HHD Study Hub. All rights reserved.</p>
           <p className="text-sm mt-1">Unofficial study support. Always refer to official VCAA materials.</p>
         </footer>

--- a/src/components/InteractiveAnnotationComponent.jsx
+++ b/src/components/InteractiveAnnotationComponent.jsx
@@ -6,21 +6,24 @@ function getInitialAnnotations(stimulus) {
     const key = 'annot_' + btoa(unescape(encodeURIComponent(stimulus))).slice(0, 16);
     const v = localStorage.getItem(key);
     return v ? JSON.parse(v) : [];
-  } catch { return []; }
+  } catch {
+    // ignore malformed data
+    return [];
+  }
 }
 function saveAnnotations(stimulus, annots) {
   try {
     const key = 'annot_' + btoa(unescape(encodeURIComponent(stimulus))).slice(0, 16);
     localStorage.setItem(key, JSON.stringify(annots));
-  } catch {}
+  } catch {
+    // ignore write errors
+  }
 }
 
 export default function InteractiveAnnotationComponent({ question, stimulus }) {
   const [annotations, setAnnotations] = useState(() => getInitialAnnotations(stimulus));
   const [drawing, setDrawing] = useState(false);
   const [drawings, setDrawings] = useState([]);
-  const [comment, setComment] = useState("");
-  const [showComment, setShowComment] = useState(null);
   const stimulusRef = useRef();
   const canvasRef = useRef();
 

--- a/src/components/InteractiveMappingComponent.jsx
+++ b/src/components/InteractiveMappingComponent.jsx
@@ -9,13 +9,19 @@ function getInitialConnections() {
 
 // Persistent storage helpers
 function saveToStorage(key, value) {
-  try { localStorage.setItem(key, JSON.stringify(value)); } catch {}
+  try {
+    localStorage.setItem(key, JSON.stringify(value));
+  } catch {
+    // ignore storage errors
+  }
 }
 function loadFromStorage(key, fallback) {
   try {
     const v = localStorage.getItem(key);
     return v ? JSON.parse(v) : fallback;
-  } catch { return fallback; }
+  } catch {
+    return fallback;
+  }
 }
 
 export default function InteractiveMappingComponent() {

--- a/src/components/SearchBar.jsx
+++ b/src/components/SearchBar.jsx
@@ -1,0 +1,52 @@
+import React, { useState } from 'react'
+
+const glossary = [
+  { term: 'Health and Wellbeing', definition: "The overall state of a person's physical, social, emotional, mental and spiritual existence." },
+  { term: 'Biomedical Approach', definition: 'Focuses on the physical or biological aspects of disease and illness, emphasising diagnosis and treatment.' },
+  { term: 'Social Model of Health', definition: 'Framework that addresses broader social, cultural and environmental determinants of health to reduce inequities.' },
+  { term: 'Ottawa Charter', definition: 'A World Health Organization framework for health promotion outlining five action areas.' },
+  { term: 'Medicare', definition: "Australia\'s universal health insurance scheme providing affordable healthcare." },
+  { term: 'Burden of Disease', definition: 'A measure of the impact of disease and injury expressed as the gap between current health status and ideal health.' },
+  { term: 'DALY', definition: 'Disability Adjusted Life Year – one year of healthy life lost due to illness, injury or premature death.' },
+  { term: 'Incidence', definition: 'The number or rate of new cases of a disease or condition during a specified period.' },
+  { term: 'Prevalence', definition: 'The total number or proportion of cases of a disease or condition in a population at a given time.' },
+]
+
+export default function SearchBar() {
+  const [query, setQuery] = useState('')
+
+  const results =
+    query.length > 0
+      ? glossary.filter(g =>
+          g.term.toLowerCase().includes(query.toLowerCase())
+        )
+      : []
+
+  return (
+    <div className="relative">
+      <input
+        type="text"
+        className="border border-slate-300 dark:border-slate-700 rounded-md py-1 px-2 bg-white dark:bg-slate-800 focus:outline-none focus:ring-2 focus:ring-purple-500 text-sm"
+        placeholder="Search glossary..."
+        value={query}
+        onChange={e => setQuery(e.target.value)}
+      />
+      {results.length > 0 && (
+        <ul className="absolute left-0 right-0 bg-white dark:bg-slate-800 border border-slate-300 dark:border-slate-700 mt-1 rounded-md shadow-lg max-h-60 overflow-y-auto z-50">
+          {results.map(item => (
+            <li
+              key={item.term}
+              className="px-3 py-2 hover:bg-purple-600 hover:text-white cursor-pointer text-sm transition-colors"
+              onClick={() => setQuery(item.term)}
+            >
+              <span className="font-semibold">{item.term}</span>
+              <p className="text-xs text-slate-600 dark:text-slate-300">
+                {item.definition}
+              </p>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  )
+}

--- a/src/index.css
+++ b/src/index.css
@@ -1,3 +1,5 @@
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap');
+
 :root {
   font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;
   line-height: 1.5;
@@ -66,8 +68,6 @@ button:focus-visible {
     background-color: #f9f9f9;
   }
 }
-/* Import Inter font from Google Fonts */
-@import url('https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap');
 body {
     font-family: 'Inter', sans-serif;
     -webkit-font-smoothing: antialiased;
@@ -75,6 +75,14 @@ body {
     display: flex;
     flex-direction: column;
     min-height: 100vh;
+    background-color: #ffffff;
+    color: #1e293b;
+    transition: background-color 0.3s ease, color 0.3s ease;
+}
+
+.dark body {
+    background-color: #1e1e2f;
+    color: #cbd5e1;
 }
 
 /* Custom scrollbar for a more modern feel (optional) */
@@ -95,12 +103,12 @@ body {
 
 /* Style for the active navigation link (desktop and mobile) */
 .nav-link.active {
-    color: #a78bfa !important; /* purple-400 */
+    color: #8b5cf6 !important; /* purple-500 */
     font-weight: 600 !important; /* semibold */
 }
 ul:not(.flex-col) > li > .nav-link.active {
-    background-color: rgba(167, 139, 250, 0.1); /* purple-400 with low opacity */
-    border-bottom: 2px solid #a78bfa; /* purple-400 */
+    background-color: rgba(139, 92, 246, 0.1); /* purple-500 with low opacity */
+    border-bottom: 2px solid #8b5cf6; /* purple-500 */
 }
 #mobile-menu .nav-link.active {
     background-color: #334155; /* slate-700, a bit darker for contrast in mobile menu */
@@ -109,10 +117,10 @@ ul:not(.flex-col) > li > .nav-link.active {
 /* Styling for content sections that will be loaded dynamically */
 /* This creates the "glossy bubble" effect for each page/section */
 .content-section {
-    background-color: #1e293b; /* slate-800, distinct from body bg-slate-900 */
+    background-color: #2a2a40;
     padding: 1.5rem; /* p-6, slightly less for mobile */
     border-radius: 0.75rem; /* rounded-xl for a softer bubble */
-    border: 1px solid #334155; /* slate-700, subtle border */
+    border: 1px solid #3b3b55;
     /* Enhanced shadow for more depth */
     box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.2), 0 10px 10px -5px rgba(0, 0, 0, 0.1); /* shadow-2xl like */
     animation: fadeIn 0.5s ease-out;
@@ -215,7 +223,7 @@ ul:not(.flex-col) > li > .nav-link.active {
 /* Style for prominent buttons within content sections */
 .button-style {
     display: inline-block;
-    background-color: #7c3aed; /* purple-600 */
+    background-color: #8b5cf6; /* purple-500 */
     color: white;
     font-weight: 600;
     padding: 0.75rem 1.5rem; /* py-3 px-6 */
@@ -225,7 +233,7 @@ ul:not(.flex-col) > li > .nav-link.active {
 }
 
 .button-style:hover {
-    background-color: #6d28d9; /* purple-700 */
+    background-color: #7c3aed; /* purple-600 */
     box-shadow: 0 10px 15px -3px rgba(0,0,0,0.1), 0 4px 6px -2px rgba(0,0,0,0.05); /* shadow-lg */
     text-decoration: none; /* Remove underline on hover for buttons */
 }

--- a/src/pages/ProgressComponent.jsx
+++ b/src/pages/ProgressComponent.jsx
@@ -1,0 +1,35 @@
+import React from 'react'
+
+const pages = [
+  { path: '/', label: 'Home' },
+  { path: '/unit3', label: 'Unit 3' },
+  { path: '/unit4', label: 'Unit 4' },
+  { path: '/assessment-prep', label: 'Assessment Prep' },
+  { path: '/glossary', label: 'Glossary' },
+  { path: '/unit3-flashcards', label: 'Flashcards' },
+  { path: '/unit3-practice', label: 'Practice Questions' },
+  { path: '/unit3-quiz', label: 'Quiz' },
+]
+
+export default function ProgressComponent() {
+  return (
+    <section className="content-section">
+      <h1 className="mb-6">Your Study Progress</h1>
+      <ul className="space-y-3">
+        {pages.map(p => {
+          const visited = localStorage.getItem('visited_' + p.path)
+          return (
+            <li key={p.path} className="flex items-center justify-between">
+              <span>{p.label}</span>
+              {visited ? (
+                <span className="text-green-500">✔</span>
+              ) : (
+                <span className="text-slate-500">✖</span>
+              )}
+            </li>
+          )
+        })}
+      </ul>
+    </section>
+  )
+}

--- a/src/pages/Unit3PracticeQuestionsComponent.jsx
+++ b/src/pages/Unit3PracticeQuestionsComponent.jsx
@@ -252,7 +252,7 @@ export default function Unit3PracticeQuestionsComponent() {
 
       {/* Questions List */}
       <div className="space-y-6">
-        {filteredQuestions.map((q, index) => (
+        {filteredQuestions.map((q) => (
           <div key={q.id} className="bg-slate-700 p-6 rounded-lg shadow-md">
             <div className="flex flex-wrap items-center gap-4 mb-3">
               <span className="bg-purple-600 text-white px-3 py-1 rounded-full text-sm font-semibold">

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,20 @@
+import { defineConfig } from 'tailwindcss'
+import typography from '@tailwindcss/typography'
+
+export default defineConfig({
+  darkMode: 'class',
+  content: ['./index.html', './src/**/*.{js,jsx}'],
+  theme: {
+    extend: {
+      colors: {
+        accent: {
+          DEFAULT: '#a855f7',
+          dark: '#9333ea'
+        },
+        outer: '#1e1e2f',
+        surface: '#2a2a40',
+      },
+    },
+  },
+  plugins: [typography],
+})


### PR DESCRIPTION
## Summary
- refine colors and layout for modern dark theme
- add Tailwind typography plugin with custom colors
- tweak navigation and mobile menu styling
- fix ESLint issues in utility components
- add search bar for glossary and progress tracker page

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684803af74ec832ca3b00da508aa0a2f