### PR TITLE
Add glossy dark theme layout

### DIFF
--- a/UI-Redesign-TODO.md
+++ b/UI-Redesign-TODO.md
@@ -1,0 +1,14 @@
+# UI Overhaul TODO
+
+This checklist outlines the steps required to modernise the interface with a dark glossy aesthetic and purple accents. Each step should be reviewed on both desktop and mobile.
+
+- [ ] Audit existing components and identify hard‑coded max widths or margins.
+- [ ] Expand layout containers so content spans the full viewport width.
+- [ ] Apply a dark gradient background with subtle purple tones for depth.
+- [ ] Update header and footer styles to match the new glossy look.
+- [ ] Replace placeholder images with higher‑quality assets where available.
+- [ ] Review typography and spacing for accessibility and readability.
+- [ ] Ensure responsive behaviour for navigation and interactive elements.
+- [ ] Test across mobile and desktop to remove any unwanted scrollbars or borders.
+- [ ] Perform final accessibility and lint checks before release.
+

--- a/src/App.css
+++ b/src/App.css
@@ -1,10 +1,10 @@
 @import url('https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap');
 
 #root {
-  max-width: 1280px;
-  margin: 0 auto;
-  padding: 2rem;
-  text-align: center;
+  width: 100%;
+  margin: 0;
+  padding: 0;
+  text-align: left;
 }
 
 .logo {

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -101,9 +101,9 @@ function App() {
     <Router>
       <ScrollToTopOnRouteChange />
 
-      <div className="font-sans antialiased min-h-screen bg-outer text-gray-100">
-        <header className="bg-surface shadow-lg sticky top-0 z-50">
-          <nav className="max-w-5xl mx-auto px-4 md:px-8 py-4 flex items-center justify-between space-x-6">
+      <div className="font-sans antialiased min-h-screen bg-gradient-to-b from-outer to-surface text-gray-100">
+        <header className="bg-surface/80 backdrop-blur shadow-lg sticky top-0 z-50">
+          <nav className="w-full px-6 md:px-8 py-4 flex items-center justify-between space-x-6">
             <Link to="/" className="text-2xl font-bold text-purple-400 hover:text-purple-300 transition-colors">HHD Hub</Link>
             <div className="flex items-center space-x-3">
               <div className="hidden md:block">
@@ -165,7 +165,7 @@ function App() {
               />
               <div
                 id="mobile-menu"
-                className="md:hidden fixed top-16 inset-x-0 bg-gray-100 dark:bg-surface z-50"
+                className="md:hidden fixed top-16 inset-x-0 bg-surface/90 backdrop-blur z-50"
               >
               <ul className="flex flex-col items-center py-2 space-y-2">
                 <li>
@@ -191,7 +191,7 @@ function App() {
           )}
         </header>
 
-        <main id="app-content" className="max-w-5xl mx-auto px-4 md:px-8 py-8 min-h-[calc(100vh-160px)]">
+        <main id="app-content" className="w-full px-6 md:px-8 py-8 min-h-[calc(100vh-160px)]">
           <Routes>
             <Route path="/" element={<Home />} />
             <Route path="/unit3" element={<Unit3 />} />
@@ -210,7 +210,7 @@ function App() {
 
         <ScrollToTopButton />
 
-        <footer className="bg-gray-100 dark:bg-surface text-slate-500 dark:text-slate-400 text-center p-6 shadow-top transition-colors">
+        <footer className="bg-surface/80 backdrop-blur text-slate-500 dark:text-slate-400 text-center p-6 shadow-top transition-colors">
 
           <p>&copy; {new Date().getFullYear()} VCE HHD Study Hub. All rights reserved.</p>
           <p className="text-sm mt-1">Unofficial study support. Always refer to official VCAA materials.</p>

--- a/src/index.css
+++ b/src/index.css
@@ -86,13 +86,15 @@ body {
     display: flex;
     flex-direction: column;
     min-height: 100vh;
+    width: 100%;
+    margin: 0;
     background-color: #ffffff;
     color: #1e293b;
     transition: background-color 0.3s ease, color 0.3s ease;
 }
 
 .dark body {
-    background-color: #1e1e2f;
+    background: linear-gradient(180deg, #1e1e2f 0%, #2a2a40 100%);
     color: #cbd5e1;
 }
 


### PR DESCRIPTION
## Summary
- add UI redesign to-do list
- remove width limits from root element
- apply dark gradient background and full-width layout
- make header/footer glossy with blur

## Testing
- `npm run lint` *(fails: 25 errors, 2 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_684a36592598832cb83abebe74449fd9