### PR TITLE
Improve accessibility

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -143,7 +143,7 @@ ul:not(.flex-col) > li > .nav-link.active {
 .content-section h4 {
     font-size: 1.125rem; /* text-lg for mobile */
     font-weight: 600; /* semibold */
-    color: #cbd5e1; /* slate-300 */
+    color: #e2e8f0; /* slate-200 */
     margin-top: 1.25rem; /* mt-5 */
     margin-bottom: 0.5rem; /* mb-2 */
 }
@@ -156,7 +156,7 @@ ul:not(.flex-col) > li > .nav-link.active {
 .content-section p {
     line-height: 1.75; /* leading-relaxed */
     margin-bottom: 1rem; /* mb-4 */
-    color: #cbd5e1; /* slate-300 */
+    color: #e2e8f0; /* slate-200 */
     font-size: 0.95rem; /* Slightly smaller for mobile */
 }
 @media (min-width: 768px) {
@@ -169,7 +169,7 @@ ul:not(.flex-col) > li > .nav-link.active {
     list-style-type: disc;
     margin-left: 1.5rem; /* ml-6 */
     margin-bottom: 1rem; /* mb-4 */
-    color: #cbd5e1; /* slate-300 */
+    color: #e2e8f0; /* slate-200 */
 }
 
 .content-section li {

--- a/src/components/FlashcardsComponent.jsx
+++ b/src/components/FlashcardsComponent.jsx
@@ -50,7 +50,7 @@ export default function FlashcardsComponent() {
 
   return (
     <div className="p-4 bg-slate-800 rounded-lg shadow-md max-w-2xl mx-auto">
-      <h2 className="text-xl font-semibold mb-4 text-purple-300">Unit 3 Glossary Flashcards</h2>
+      <h2 className="text-xl font-semibold mb-4 text-purple-200">Unit 3 Glossary Flashcards</h2>
       <div className="text-2xl font-bold mb-2">{card.term}</div>
       {showDef && (
         <div className="mb-4">{card.definition}</div>

--- a/src/components/QuizComponent.jsx
+++ b/src/components/QuizComponent.jsx
@@ -150,7 +150,7 @@ export default function QuizComponent() {
       {/* Header */}
       <div className="mb-6">
         <h2 className="text-3xl font-bold text-purple-400 mb-2">Unit 3 Self-Check Quiz</h2>
-        <p className="text-slate-400 max-w-2xl">
+        <p className="text-slate-300 max-w-2xl">
           Test your understanding of key VCE HHD concepts. Filter by category and favorite challenging questions for review.
         </p>
       </div>
@@ -196,13 +196,13 @@ export default function QuizComponent() {
           </div>
 
           {totalAnswered > 0 && (
-            <div className="text-xs text-slate-400">
+            <div className="text-xs text-slate-300">
               Progress: {totalAnswered}/{filteredQuestions.length} answered
             </div>
           )}
 
           <button
-            className="p-1 rounded-full bg-slate-800 text-slate-400 hover:text-purple-300 focus:outline-none focus:ring-2 focus:ring-purple-400"
+            className="p-3 w-12 h-12 rounded-full bg-slate-800 text-slate-300 hover:text-purple-200 focus:outline-none focus:ring-2 focus:ring-purple-400"
             aria-label="Quiz help"
             title="How to use the quiz"
             onClick={() =>
@@ -248,10 +248,10 @@ export default function QuizComponent() {
                 
                 <button
                   type="button"
-                  className={`p-1 rounded-full focus:outline-none focus:ring-2 focus:ring-yellow-400 transition-transform duration-150 ${
+                  className={`p-3 w-12 h-12 rounded-full focus:outline-none focus:ring-2 focus:ring-yellow-400 transition-transform duration-150 ${
                     isFavorite
                       ? "text-yellow-400 scale-110"
-                      : "text-slate-400 hover:text-yellow-400 hover:scale-110"
+                      : "text-slate-300 hover:text-yellow-400 hover:scale-110"
                   }`}
                   onClick={() => toggleFavorite(q.id)}
                   aria-label={isFavorite ? `Remove question ${q.id} from favorites` : `Add question ${q.id} to favorites`}
@@ -318,7 +318,7 @@ export default function QuizComponent() {
         })}
 
         {filteredQuestions.length === 0 && (
-          <div className="text-center py-12 text-slate-400">
+          <div className="text-center py-12 text-slate-300">
             <svg className="w-16 h-16 mx-auto mb-4 text-slate-500" fill="none" stroke="currentColor" strokeWidth="1" viewBox="0 0 24 24">
               <path strokeLinecap="round" strokeLinejoin="round" d="M9.172 16.172a4 4 0 015.656 0M9 12h6m-6-4h6m2 5.291A7.962 7.962 0 0112 15c-2.34 0-4.488.901-6.077 2.378l-.096.074c-.487.365-.896.833-1.208 1.386C4.392 19.394 4.259 20 4.5 20.5S5.606 21 6.162 21h11.676c.556 0 1.054-.606.792-1.122a7.929 7.929 0 00-1.208-1.386l-.096-.074z" />
             </svg>
@@ -346,7 +346,7 @@ export default function QuizComponent() {
                 {score}/{filteredQuestions.length}
               </span>
             </div>
-            <p className="text-slate-400 mb-4">
+            <p className="text-slate-300 mb-4">
               {score >= filteredQuestions.length * 0.8 ? "Excellent work! 🎉" :
                score >= filteredQuestions.length * 0.6 ? "Good effort! Keep studying! 📚" :
                "Keep practicing! Review the explanations below. 💪"}

--- a/src/components/SearchBar.jsx
+++ b/src/components/SearchBar.jsx
@@ -24,7 +24,11 @@ export default function SearchBar() {
 
   return (
     <div className="relative w-full max-w-xs">
+      <label htmlFor="glossary-search" className="sr-only">
+        Search glossary
+      </label>
       <input
+        id="glossary-search"
         type="text"
         className="w-full border border-slate-300 dark:border-slate-700 rounded-md py-1 px-2 bg-white dark:bg-slate-800 focus:outline-none focus:ring-2 focus:ring-purple-500 text-sm transition-colors"
         placeholder="Search glossary..."

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -5,12 +5,20 @@ export default function Sidebar() {
   const [isOpen, setIsOpen] = useState(true);
 
   return (
-    <div className={`transition-all duration-300 bg-gray-800 text-white h-screen overflow-hidden ${isOpen ? 'w-64' : 'w-0'}`}>
-      <button onClick={() => setIsOpen(!isOpen)} className="p-2 focus:outline-none">
+    <aside
+      className={`transition-all duration-300 bg-gray-800 text-white h-screen overflow-hidden ${
+        isOpen ? 'w-64' : 'w-0'
+      }`}
+    >
+      <button
+        onClick={() => setIsOpen(!isOpen)}
+        aria-label="Toggle sidebar"
+        className="p-3 w-12 h-12 flex items-center justify-center focus:outline-none"
+      >
         🍔
       </button>
       {isOpen && (
-        <nav className="flex flex-col space-y-4 p-4">
+        <nav className="flex flex-col space-y-4 p-4" aria-label="Primary">
           <Link to="/">Home</Link>
           <Link to="/unit3">Unit 3</Link>
           <Link to="/unit4">Unit 4</Link>
@@ -18,6 +26,6 @@ export default function Sidebar() {
           <Link to="/glossary">Glossary</Link>
         </nav>
       )}
-    </div>
+    </aside>
   );
 }


### PR DESCRIPTION
## Summary
- add ARIA label and aside element to sidebar toggle
- add hidden label to glossary search bar
- improve flashcards and quiz colors for readability
- enlarge icon buttons for touch targets
- lighten paragraph and list text colors

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685223e8bd40832c8a3412682753b06e