### PR TITLE
UI tweaks for better layout

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -20,7 +20,7 @@ export default function App() {
     <Router>
       <div className="flex min-h-screen bg-gray-900 text-white">
         <Sidebar />
-        <main className="flex-1 p-4">
+        <main className="flex-1 px-4 lg:px-8 w-full max-w-screen-xl mx-auto">
           <Suspense fallback={<div>Loading...</div>}>
             <Routes>
               <Route path="/" element={<Home />} />

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -1,21 +1,38 @@
 import { Link } from 'react-router-dom';
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 
 export default function Sidebar() {
-  const [isOpen, setIsOpen] = useState(true);
+  const [isOpen, setIsOpen] = useState(false);
+
+  useEffect(() => {
+    if (window.innerWidth >= 768) {
+      setIsOpen(true);
+    }
+  }, []);
 
   return (
     <aside
-      className={`transition-all duration-300 bg-gray-800 text-white h-screen overflow-hidden ${
-        isOpen ? 'w-64' : 'w-0'
+      className={`bg-gray-800 text-white transition-all duration-300 h-screen overflow-y-auto flex flex-col z-20 fixed md:static top-0 left-0 ${
+        isOpen ? 'w-64' : 'w-16'
       }`}
     >
       <button
         onClick={() => setIsOpen(!isOpen)}
         aria-label="Toggle sidebar"
-        className="p-3 w-12 h-12 flex items-center justify-center focus:outline-none"
+        className="p-3 w-16 h-16 flex items-center justify-center focus:outline-none hover:bg-gray-700"
       >
-        ≡
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          viewBox="0 0 24 24"
+          fill="currentColor"
+          className="w-6 h-6"
+        >
+          <path
+            fillRule="evenodd"
+            d="M3.75 5.25a.75.75 0 000 1.5h16.5a.75.75 0 000-1.5H3.75zm0 6a.75.75 0 000 1.5h16.5a.75.75 0 000-1.5H3.75zm0 6a.75.75 0 000 1.5h16.5a.75.75 0 000-1.5H3.75z"
+            clipRule="evenodd"
+          />
+        </svg>
       </button>
       {isOpen && (
         <nav className="flex flex-col space-y-4 p-4" aria-label="Primary">

--- a/src/pages/HomeComponent.jsx
+++ b/src/pages/HomeComponent.jsx
@@ -49,9 +49,9 @@ export default function HomeComponent() {
   // ];
 
   return (
-    <section className="content-section text-center">
-      <h1 className="text-5xl font-bold mb-6">Welcome to the HHD Study Hub!</h1>
-      <p className="text-xl mb-8">Your central resource for VCE Health and Human Development.</p>
+    <section className="content-section text-center prose prose-invert max-w-none">
+      <h1 className="text-3xl md:text-5xl font-bold leading-snug mb-6">Welcome to the HHD Study Hub!</h1>
+      <p className="text-lg tracking-wide mb-8">Your central resource for VCE Health and Human Development.</p>
       <img
         src="https://placehold.co/800x400/1e293b/e2e8f0?text=HHD+Concept+Image"
         alt="HHD Concept Image"
@@ -62,9 +62,22 @@ export default function HomeComponent() {
         }}
       />
       <p className="mb-4">This website is designed to help you navigate the complexities of the VCE HHD curriculum, starting with Unit 3 and expanding to Unit 4.</p>
-      <p>Explore key knowledge, practice skills, and prepare for your assessments with our curated content.</p>
+      <p className="tracking-wide">Explore key knowledge, practice skills, and prepare for your assessments with our curated content.</p>
       <div className="mt-10">
-        <Link to="/unit3" className="button-style">
+        <Link
+          to="/unit3"
+          className="inline-flex items-center bg-purple-600 hover:bg-purple-700 text-white px-4 py-2 rounded-xl shadow-md hover:shadow-lg transition"
+        >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            fill="none"
+            viewBox="0 0 24 24"
+            strokeWidth={1.5}
+            stroke="currentColor"
+            className="w-5 h-5 mr-2"
+          >
+            <path strokeLinecap="round" strokeLinejoin="round" d="M4.5 12.75l6 6 9-13.5" />
+          </svg>
           Explore Unit 3
         </Link>
       </div>


### PR DESCRIPTION
## Summary
- make sidebar collapsed by default and add hamburger icon
- widen main layout container
- apply typography classes to the home page and modern CTA styles

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68522badb358832cb6eb3e4c7c7bcd31