### PR TITLE
Fix glossary rendering

### DIFF
--- a/src/pages/GlossaryComponent.jsx
+++ b/src/pages/GlossaryComponent.jsx
@@ -365,12 +365,12 @@ export default function GlossaryComponent() {
 		return stored ? JSON.parse(stored) : [];
 	});
 	const [showOnlyFavorites, setShowOnlyFavorites] = useState(false);
-	const filteredTerms = useMemo(() => {
-		let terms = glossaryTerms.filter(
-			({ term, definition }) =>
-				term.toLowerCase().includes(search.toLowerCase()) ||
-				definition.toLowerCase().includes(search.toLowerCase())
-		);
+        const filteredTerms = useMemo(() => {
+                let terms = glossaryTerms.filter(
+                        ({ term, definition }) =>
+                                term.toLowerCase().includes(search.toLowerCase()) ||
+                                (definition || "").toLowerCase().includes(search.toLowerCase())
+                );
 		if (showOnlyFavorites) {
 			terms = terms.filter(({ term }) => favorites.includes(term));
 		}


### PR DESCRIPTION
## Summary
- ensure glossary filter handles missing definitions

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685229f05b88832cae0249262fbcccd5